### PR TITLE
avoid using go/build to trim prefix

### DIFF
--- a/stacktrace.go
+++ b/stacktrace.go
@@ -7,9 +7,7 @@ package raven
 
 import (
 	"bytes"
-	"go/build"
 	"io/ioutil"
-	"path/filepath"
 	"runtime"
 	"strings"
 	"sync"
@@ -199,25 +197,15 @@ func fileContext(filename string, line, context int) ([][]byte, int) {
 	return lines[start:end], idx
 }
 
-var trimPaths []string
-
-// Try to trim the GOROOT or GOPATH prefix off of a filename
+// trimPath tries to trim the GOROOT or GOPATH prefix off of a filename.
+//
+// We don't use `go/build` here as it will look at the _current_ values,
+// so instead we just assume the last `/src/`.
 func trimPath(filename string) string {
-	for _, prefix := range trimPaths {
-		if trimmed := strings.TrimPrefix(filename, prefix); len(trimmed) < len(filename) {
-			return trimmed
-		}
+	const src = "/src/"
+	prefix := strings.LastIndex(filename, src)
+	if prefix == -1 {
+		return filename
 	}
-	return filename
-}
-
-func init() {
-	// Collect all source directories, and make sure they
-	// end in a trailing "separator"
-	for _, prefix := range build.Default.SrcDirs() {
-		if prefix[len(prefix)-1] != filepath.Separator {
-			prefix += string(filepath.Separator)
-		}
-		trimPaths = append(trimPaths, prefix)
-	}
+	return filename[prefix+len(src):]
 }


### PR DESCRIPTION
go/build will return gopath/goroot paths for the machine running it, which isn't what you want --
the path being stripped are from the build machine. a dumber approach, just looking for /src/ does
almost the same thing without using go/build.