### PR TITLE
Change Module Declaration to cockroachdb/raven-go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/tooolbox/raven-go
+module github.com/cockroachdb/raven-go
 
 go 1.13
 


### PR DESCRIPTION
Trying to import `cockroachdb/raven-go` gives this error: 
> go: finding github.com/cockroachdb/raven-go 6c81622bd68c7753d2c4fefe9619f02d83a29782
> go: github.com/cockroachdb/raven-go@v0.0.0-20191217143556-6c81622bd68c: parsing go.mod:
	module declares its path as: github.com/tooolbox/raven-go
	        but was required as: github.com/cockroachdb/raven-go

Looks like [in the last merge](https://github.com/cockroachdb/raven-go/commit/6c81622bd68c7753d2c4fefe9619f02d83a29782) I didn't fix the module name.  My bad!

This PR sets the module name to the correct value.